### PR TITLE
URSA-54: Oid local edges list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy
 pytest>=2.8
 ray>=0.3.0
 setuptools==18.5

--- a/test/local_manager_test.py
+++ b/test/local_manager_test.py
@@ -53,7 +53,7 @@ def test_insert_and_select_roundtrip():
     assert ray.get(row_query1) == "Value1"
 
     l_key_query1 = manager.select_local_edges(test_graph_id, "Key1")
-    assert ray.get(l_key_query1) == set()
+    assert ray.get(l_key_query1) == []
 
     f_key_query1 = manager.select_foreign_edges(test_graph_id, "Key1")
     assert f_key_query1 == {}
@@ -64,11 +64,11 @@ def test_insert_and_select_roundtrip():
     assert ray.get(row_query2) == "Value2"
 
     l_key_query2 = manager.select_local_edges(test_graph_id, "Key2")
-    assert ray.get(l_key_query2) == set(["Key1"])
+    assert ray.get(l_key_query2) == ["Key1"]
 
     # testing the bi-directionality invariant
     l_key_query1 = manager.select_local_edges(test_graph_id, "Key1")
-    assert ray.get(l_key_query1) == set(["Key2"])
+    assert ray.get(l_key_query1) == ["Key2"]
 
     f_key_query2 = manager.select_foreign_edges(test_graph_id, "Key1")
     assert f_key_query2 == {}
@@ -81,7 +81,7 @@ def test_insert_and_select_roundtrip():
     assert ray.get(row_query3) == "Value3"
 
     l_key_query3 = manager.select_local_edges(test_graph_id, "Key3")
-    assert ray.get(l_key_query3) == set()
+    assert ray.get(l_key_query3) == []
 
     f_key_query3 = manager.select_foreign_edges(test_graph_id, "Key3")
     assert ray.get(f_key_query3["Other Graph"]) == set(["Foreign Key"])
@@ -91,19 +91,19 @@ def test_add_local_edges():
     manager = init_test()
     manager.insert(test_graph_id, "Key1", "Value1")
     l_key_query1 = manager.select_local_edges(test_graph_id, "Key1")
-    assert ray.get(l_key_query1) == set()
+    assert ray.get(l_key_query1) == []
 
     manager.insert(test_graph_id, "Key2", "Value2")
     l_key_query2 = manager.select_local_edges(test_graph_id, "Key2")
-    assert ray.get(l_key_query2) == set()
+    assert ray.get(l_key_query2) == []
 
     manager.add_local_edges(test_graph_id, "Key2", "Key1")
 
     l_key_query2 = manager.select_local_edges(test_graph_id, "Key2")
-    assert ray.get(l_key_query2) == set(["Key1"])
+    assert ray.get(l_key_query2) == ["Key1"]
 
     l_key_query1 = manager.select_local_edges(test_graph_id, "Key1")
-    assert ray.get(l_key_query1) == set(["Key2"])
+    assert ray.get(l_key_query1) == ["Key2"]
 
 
 def test_add_foreign_edges():

--- a/test_script.sh
+++ b/test_script.sh
@@ -9,7 +9,7 @@ source activate ursa-python3-${uuid}
 make prepare
 
 # run flake8
-python3 -m flake8 --exclude env,__pycache__,.git
+python3 -m flake8
 
 if [ $? -ne 0 ]; then
 	echo "Please fix flake8 errors."
@@ -17,9 +17,9 @@ if [ $? -ne 0 ]; then
 fi
 
 # run pytest for python3 on all test files
-python3 -m pytest test/local_manager_test.py
-python3 -m pytest test/graph_test.py
-python3 -m pytest test/test_connected_components.py
+python3 -m pytest -v test/local_manager_test.py
+python3 -m pytest -v test/graph_test.py
+#python3 -m pytest -v test/test_connected_components.py
 
 # deactivate and remove the conda env
 source deactivate
@@ -34,9 +34,9 @@ source activate ursa-python2-${uuid}
 make prepare
 
 #run pytest for python2 on all test files
-python2 -m pytest test/local_manager_test.py
-python2 -m pytest test/graph_test.py
-python2 -m pytest test/test_connected_components.py
+python2 -m pytest -v test/local_manager_test.py
+python2 -m pytest -v test/graph_test.py
+#python2 -m pytest -v test/test_connected_components.py
 
 # deactivate and remove the conda env
 source deactivate

--- a/test_script.sh
+++ b/test_script.sh
@@ -9,7 +9,7 @@ source activate ursa-python3-${uuid}
 make prepare
 
 # run flake8
-python3 -m flake8
+python3 -m flake8 --exclude env,__pycache__,.git
 
 if [ $? -ne 0 ]; then
 	echo "Please fix flake8 errors."

--- a/ursa/graph/local_edges.py
+++ b/ursa/graph/local_edges.py
@@ -1,0 +1,51 @@
+import ray
+
+
+class LocalEdges(object):
+    """
+    This object contains a list of edges (both local and in
+    Ray's object store) corresponding to a node.
+
+    Fields:
+    edges -- list of OID's (each OID respresents a list of edges in Ray)
+    buf -- list of edges not yet flushed to Ray
+    """
+
+    MAX_SUBLIST_SIZE = 10
+
+    def __init__(self, edges=[]):
+        if type(edges) is not ray.local_scheduler.ObjectID:
+            if isinstance(edges, list) and all(isinstance(
+                    edge, ray.local_scheduler.ObjectID) for edge in edges):
+                self.edges = edges
+            else:
+                try:
+                    self.edges = [ray.put(set([edges]))]
+                except TypeError:
+                    self.edges = [ray.put(set(edges))]
+        else:
+            self.edges = [edges]
+
+        self.buf = []
+
+    def add_local_edges(self, transaction_id, *values):
+        """
+        values are edge objects
+        """
+        for value in values:
+            self.buf.append(value)
+            if len(self.buf) >= self.MAX_SUBLIST_SIZE:
+                new_oid = ray.put(self.buf)
+                self.edges.append(new_oid)
+                self.buf = []
+
+        return self.copy(self.edges)
+
+    def get_edges_oids(self):
+        return self.edges
+
+    def get_buffered_edges(self):
+        return self.buf
+
+    def copy(self, edges=[]):
+        return LocalEdges(edges)

--- a/ursa/graph/local_edges.py
+++ b/ursa/graph/local_edges.py
@@ -9,8 +9,8 @@ class LocalEdges(object):
     This object contains a list of edges (both local and in Ray's object store)
     corresponding to a node.
 
-    @field edges: list of OIDs (each OID represents a list of edges in Ray).
-    @field buf: list of edges not yet flushed to Ray.
+    @field edges: List of OIDs (each OID represents a list of edges in Ray).
+    @field buf: List of edges not yet flushed to Ray.
     """
     def __init__(self, *edges):
         """Constructor for LocalEdges class
@@ -30,7 +30,7 @@ class LocalEdges(object):
     def append(self, *values):
         """Append new values to the edge list.
 
-        @param values: values are edge objects.
+        @param values: Values are edge objects.
 
         @return: A list of edges including the new appended values.
         """

--- a/ursa/graph/local_edges.py
+++ b/ursa/graph/local_edges.py
@@ -1,51 +1,77 @@
 import ray
+import numpy as np
+
+MAX_SUBLIST_SIZE = 10
 
 
 class LocalEdges(object):
     """
-    This object contains a list of edges (both local and in
-    Ray's object store) corresponding to a node.
+    This object contains a list of edges (both local and in Ray's object store)
+    corresponding to a node.
 
-    Fields:
-    edges -- list of OID's (each OID respresents a list of edges in Ray)
-    buf -- list of edges not yet flushed to Ray
+    @field edges: list of OIDs (each OID represents a list of edges in Ray).
+    @field buf: list of edges not yet flushed to Ray.
     """
+    def __init__(self, *edges):
+        """Constructor for LocalEdges class
 
-    MAX_SUBLIST_SIZE = 10
-
-    def __init__(self, edges=[]):
-        if type(edges) is not ray.local_scheduler.ObjectID:
-            if isinstance(edges, list) and all(isinstance(
-                    edge, ray.local_scheduler.ObjectID) for edge in edges):
-                self.edges = edges
-            else:
-                try:
-                    self.edges = [ray.put(set([edges]))]
-                except TypeError:
-                    self.edges = [ray.put(set(edges))]
-        else:
-            self.edges = [edges]
-
-        self.buf = []
-
-    def add_local_edges(self, transaction_id, *values):
+        @param edges: One or more edges to initialize this object.
         """
-        values are edge objects
+        self.edges = \
+            [obj for obj in edges if type(obj) is ray.local_scheduler.ObjectID]
+
+        self.buf = \
+            np.array([obj for obj in edges
+                      if type(obj) is not ray.local_scheduler.ObjectID])
+        if len(self.buf) > MAX_SUBLIST_SIZE:
+            self.edges.append(ray.put(self.buf))
+            self.buf = np.array([])
+
+    def append(self, *values):
+        """Append new values to the edge list.
+
+        @param values: values are edge objects.
+
+        @return: A list of edges including the new appended values.
         """
-        for value in values:
-            self.buf.append(value)
-            if len(self.buf) >= self.MAX_SUBLIST_SIZE:
-                new_oid = ray.put(self.buf)
-                self.edges.append(new_oid)
-                self.buf = []
+        temp_edges = self.edges[:]
+        temp_edges.extend([val for val in values
+                           if type(val) is ray.local_scheduler.ObjectID])
+        temp_buf = \
+            np.append(self.buf,
+                      [val for val in values
+                       if type(val) is not ray.local_scheduler.ObjectID])
 
-        return self.copy(self.edges)
+        if len(temp_buf) > MAX_SUBLIST_SIZE:
+            temp_edges.append(ray.put(self.buf))
+            temp_buf = np.array([])
 
-    def get_edges_oids(self):
-        return self.edges
+        temp_edges.extend(temp_buf)
+        return temp_edges
 
-    def get_buffered_edges(self):
-        return self.buf
+    def filter(self, filterfn):
+        """Apply a filter function to the list of edges.
 
-    def copy(self, edges=[]):
-        return LocalEdges(edges)
+        @param filterfn: The filter function to be applied to the list of
+                         edges.
+        @return: The filtered list of edges.
+        """
+        new_edges = [_filter_remote.remote(filterfn, chunk)
+                     for chunk in self.edges]
+        new_buf = np.array(filter(filterfn, self.buf))
+        new_edges.extend(new_buf)
+
+        return new_edges
+
+
+@ray.remote
+def _filter_remote(filterfn, chunk):
+    """Apply a filter function to an object.
+
+    @param filterfn: The filter function to be applied to the list of
+                     edges.
+    @param chunk: The object to which the filter will be applied.
+
+    @return: An array of filtered objects.
+    """
+    return np.array(filter(filterfn, chunk))

--- a/ursa/local_manager.py
+++ b/ursa/local_manager.py
@@ -188,8 +188,10 @@ class GraphManager(object):
 
         @return: The Object ID(s) of the local edges.
         """
-        return ray.get(self.graph_dict[graph_id].select_local_edges.remote(
-            self._transaction_id, key))[0]
+        edges_oid, buffer_oid = self.graph_dict[graph_id].\
+                        select_local_keys.remote(self._transaction_id, key)
+        return [item for l in ray.get(ray.get(
+            edges_oid)).append(ray.get(buffer_oid)) for item in l]
 
     def select_foreign_edges(self, graph_id, key=None):
         """Gets all foreign edges for the graph/key specified.


### PR DESCRIPTION
Added optimization to avoid copying large amounts of data in the Ray object store.

Major changes:
- No longer using sets for the edges -- numpy arrays serialize better
- No more connected components -- previous implementation did not scale, and it was not worth refactoring with the new optimizations
- local edges have both a buffer and a list of oids